### PR TITLE
ti: Update baseline to 11.01.03 for `current`

### DIFF
--- a/config/sources/families/k3.conf
+++ b/config/sources/families/k3.conf
@@ -48,11 +48,11 @@ case "${BRANCH}" in
 
 	current | current-rt)
 
-		declare -g CORESDK_TAG="tag:11.00.09"
+		declare -g CORESDK_TAG="tag:11.01.03"
 		declare -g KERNEL_MAJOR_MINOR="6.12"
 		declare -g KERNELBRANCH="${CORESDK_TAG}"
 		declare -g KERNEL_DESCRIPTION="Texas Instruments currently supported SDK (vendor) kernel"
-		declare -g ATFBRANCH="commit:b11beb2b6bd30b75c4bfb0e9925c0e72f16ca53f"
+		declare -g ATFBRANCH="commit:39fe4a856d3576646642c2516b7a99de63eca74e"
 		declare -g OPTEE_BRANCH="tag:4.6.0"
 		declare -g TI_LINUX_FIRMWARE_BRANCH="${CORESDK_TAG}"
 		declare -g BOOTBRANCH="${CORESDK_TAG}"


### PR DESCRIPTION
UPSTREAM STATUS: Won't upstream this, since its not a release RC.